### PR TITLE
Make it work for the laconic subpage buttons

### DIFF
--- a/components/config.ts
+++ b/components/config.ts
@@ -1,4 +1,5 @@
-export const HOVER_SELECTOR = ".twikilink",
+export const HOVER_SELECTOR =
+    ".twikilink, .subpage-link[title='The Laconic page']:not(.curr-subpage)",
   DARK_MODE_COOKIE = "night-vision=true",
   INITIAL_CONTENT = "Loading…",
   DARK_THEME = "dark",

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -17,7 +17,6 @@ export default defineContentScript({
       placement: "top-start",
       ignoreAttributes: true,
       allowHTML: true,
-      appendTo: "parent",
       animation: "perspective",
       delay: 100,
       content: INITIAL_CONTENT,


### PR DESCRIPTION
Right now if you arrive at a trope from Google, you'll have to go to the laconic tab afterwards.