### PR TITLE
Fix heading having too much text

### DIFF
--- a/components/api.ts
+++ b/components/api.ts
@@ -83,7 +83,7 @@ export class Trope {
   }
 
   private extractTitle(document: Document) {
-    const titleElement = document.querySelector(".entry-title");
+    const titleElement = document.querySelector(".entry-title a");
     if (titleElement?.textContent) {
       return titleElement.textContent.trim();
     }


### PR DESCRIPTION
Fixes a bug on the current site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title detection to read the text from the linked heading, preventing empty or incorrect titles on certain pages.
  * Ensures more consistent and accurate titles when pages wrap headings in links.
  * Reduces instances of missing titles and improves overall reliability of content extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->